### PR TITLE
Add Toprank

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Full-featured coding agents that work from the command line.
 | [Crush](https://github.com/charmbracelet/crush) | Free | TUI workflows | Terminal-native AI coding agent with a polished TUI experience. |
 | [Qwen Code](https://github.com/QwenLM/qwen-code) | Free | Qwen users | Open-source coding CLI optimized for Qwen coder models. |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | Free tier | Long-context workflows | CLI coding assistant with strong context handling and agent flows. |
+| [Toprank](https://github.com/nowork-studio/toprank) | Free | SEO & marketing workflows | Open-source Claude Code plugin for SEO, Google Ads, content writing, and CMS optimization workflows. |
 | 🔥 [Aider](https://aider.chat/) | Free | Git integration | Best open-source AI pair programmer. Works with any editor, commits changes. |
 | [Goose](https://github.com/block/goose) | Free | Extensibility | Block's open-source AI developer agent. Plugin system for custom tools. |
 | [RA.Aid](https://github.com/ai-christianson/RA.Aid) | Free | Research tasks | Research-focused AI dev agent. Combines coding with information gathering. |


### PR DESCRIPTION
## Summary
- add `nowork-studio/toprank` to AI Coding CLIs
- describe it as an open-source Claude Code plugin for SEO, Google Ads, content writing, and CMS optimization workflows

## Credibility
`nowork-studio/toprank` currently has **115 GitHub stars**.

## Why it fits
Toprank is a GitHub-hosted Claude Code plugin that extends terminal-based AI coding with practical optimization workflows, which fits this curated vibe-coding list.