### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Tools for specific coding workflows.
 | [Claude Task Master](https://github.com/eyaltoledano/claude-task-master) | Free | Project management | AI-driven task management for dev projects. Integrates with Claude. |
 | [vibe-kanban](https://github.com/BloopAI/vibe-kanban) | Free | Agent orchestration | Kanban-style control plane for coordinating AI coding agents. |
 | [Ivy Tendril](https://github.com/Ivy-Interactive/Ivy-Tendril) | Free | Agent orchestration | Open-source AI coding orchestrator. Manages Claude Code, Codex, Antigravity through plan-based lifecycle with verification gates and self-improving memory. |
+| [agenttrace](https://github.com/luoyuctl/agenttrace) | Free | Session observability | Local TUI for auditing AI coding-agent runs, token usage, costs, tool failures, latency, anomalies, diffs, and CI gates. |
 | [GPT Pilot](https://github.com/Pythagora-io/gpt-pilot) | Free | Full app dev | Builds entire apps from scratch. Interactive development with AI. |
 | [Sweep](https://sweep.dev/) | Free tier | GitHub PRs | AI junior developer. Handles issues and creates PRs automatically. |
 


### PR DESCRIPTION
## Summary

Add agenttrace to Specialized CLI Tools.

## Type of Change

- [x] New tool/resource
- [ ] Update existing entry
- [ ] Fix broken link
- [ ] Improve documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] Tool/resource follows the awesome list format
- [x] Links are working and tested
- [x] Entry includes: Tool name, Pricing, Best For, Why It is Awesome
- [x] No promotional/marketing language (focus on utility)
- [x] Alphabetical order maintained (if applicable)

## Additional Context

agenttrace is a local TUI for auditing AI coding-agent runs across Claude Code, Codex CLI, Gemini CLI, Aider, and related session logs. It surfaces token usage, costs, tool failures, latency, anomalies, diffs, and CI gates, so it fits the Specialized CLI Tools section.

Validation:

- `git diff --check`
- Verified repository metadata with `gh repo view luoyuctl/agenttrace`
- `npx --yes awesome-lint` was attempted locally but failed with `Awesome list must reside in a valid git repository`; the same workflow has recent successful runs on `main`, so this appears to be a local environment limitation rather than an entry-format issue.
