### PR TITLE
Add Parallel Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ AI that doesn't just assist — it works independently on complex tasks. [Creati
 | [GitHub Copilot Workspace](https://githubnext.com/projects/copilot-workspace) | Subscription | GitHub-native workflows | Issue-to-PR agent. Reads your repo, proposes a plan, implements changes, and opens a pull request — all from a GitHub issue. [Alternatives →](https://www.taskade.com/blog/github-copilot-alternatives) |
 | [Jules](https://jules.google/) | Free preview | Async bug fixes | Google's autonomous coding agent. Handles GitHub issues asynchronously with multi-step planning and execution. [Alternatives →](https://www.taskade.com/blog/devin-ai-alternatives) |
 | [OpenCode](https://github.com/sst/opencode) | Free | Coordination | Open-source coding agent for iterative implementation and review loops. |
+| [Parallel Code](https://github.com/johannesjo/parallel-code) | Free | Parallel local agents | Open-source desktop app for running Claude Code, Codex CLI, Gemini CLI, and other terminal agents in parallel, with per-task Git worktrees, terminal panes, diff review, and merge controls. |
 
 ---
 
@@ -1332,4 +1333,3 @@ This awesome list is maintained by [Taskade](https://www.taskade.com) with contr
 </a>
 
 Made with [contrib.rocks](https://contrib.rocks).
-


### PR DESCRIPTION
Adds Parallel Code to the AI agents and autonomous coding section.

Parallel Code is a free, MIT-licensed desktop app for running terminal-based coding agents such as Claude Code, Codex CLI, and Gemini CLI in parallel. Each task runs in its own Git branch and worktree, with terminal panes, diff review, and merge controls.