### PR TITLE
Add Wikivibe

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,7 @@ Files and templates that help AI understand your codebase.
 | [cursor-rules](https://github.com/PatrickJS/awesome-cursorrules) | Collection | Curated .cursorrules files for different frameworks and languages. |
 | [Claude Code Plugins](https://github.com/anthropics/claude-code/tree/main/plugins) | Examples | Official plugin examples for extending Claude Code capabilities. |
 | [llms.txt](https://llmstxt.org/) | Spec | Standard for making websites AI-friendly. Provide structured context to LLMs visiting your site. |
+| [Wikivibe](https://wikivibe.ru/en/) | Knowledge Base | Practical AI-assisted development guides, glossary, jobs, and a public MCP endpoint for agent-readable context. |
 
 ### Prompt Templates
 


### PR DESCRIPTION
Adds Wikivibe as a practical AI-assisted development knowledge base with guides, a glossary, jobs, and a public MCP endpoint.

Checked: link opens successfully at https://wikivibe.ru/en/.