### PR TITLE
Add ax session observability tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Tools for specific coding workflows.
 | [vibe-kanban](https://github.com/BloopAI/vibe-kanban) | Free | Agent orchestration | Kanban-style control plane for coordinating AI coding agents. |
 | [Ivy Tendril](https://github.com/Ivy-Interactive/Ivy-Tendril) | Free | Agent orchestration | Open-source AI coding orchestrator. Manages Claude Code, Codex, Antigravity through plan-based lifecycle with verification gates and self-improving memory. |
 | [agenttrace](https://github.com/luoyuctl/agenttrace) | Free | Session observability | Local TUI for auditing AI coding-agent runs, token usage, costs, tool failures, latency, anomalies, diffs, and CI gates. |
+| [ax](https://github.com/Necmttn/ax) | Free | Session observability | Local telemetry and recall graph for Claude Code, Codex, Cursor, OpenCode, and Pi sessions, tools, skills, and cost. |
 | [GPT Pilot](https://github.com/Pythagora-io/gpt-pilot) | Free | Full app dev | Builds entire apps from scratch. Interactive development with AI. |
 | [Sweep](https://sweep.dev/) | Free tier | GitHub PRs | AI junior developer. Handles issues and creates PRs automatically. |
 


### PR DESCRIPTION
Adds ax to Specialized CLI Tools.

Resource: https://github.com/Necmttn/ax

Why it fits: ax is an open-source local observability and recall tool for AI coding workflows, covering Claude Code, Codex, Cursor, OpenCode, and Pi session history, tool calls, skills, and cost.

Checks run:

- `git diff --check`
- Added GitHub link returns 200
- `npx -y markdownlint-cli2 README.md` remains at the existing 710 baseline errors from the clean checkout

---

_Generated with [ax](https://github.com/Necmttn/ax)._