### PR TITLE
Add Playcode to AI Website Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ Generate websites from descriptions, not wireframes. [Best AI website generators
 | [10Web](https://10web.io/) | Paid | WordPress | AI-generated WordPress sites with hosting included. |
 | [Hostinger AI](https://www.hostinger.com/ai-website-builder) | Paid | Beginners | Simple AI website builder with hosting bundled. |
 | [Wix ADI](https://www.wix.com/adi) | Free tier | Non-technical | Answer questions, get a website. Extremely beginner-friendly. |
+| [Playcode](https://playcode.io/ai-website-builder) | Free tier | Non-technical teams | Describe a site in plain English and Playcode's AI builds it, then Playcode Cloud runs it with hosting, a database, custom domains, SSL, snapshots, and one-click rollback. Visual editing and AI chat iteration included. |
 
 ---
 


### PR DESCRIPTION
Adds **Playcode** to the **AI Website Builders** table.

Playcode is an AI website/app builder for non-technical teams: you describe a site in plain English, the AI builds it, and Playcode Cloud runs it with hosting, a database, custom domains, SSL, snapshots, and one-click rollback. It also supports visual editing and AI chat iteration.

It fits alongside the existing entries (Durable, Wix ADI, Framer) as a prompt-to-site builder, with the added Cloud/back-end + rollback angle. Single-row addition, table format preserved.

- Site: https://playcode.io/ai-website-builder