### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Tools that give AI agents persistent memory and context.
 | [Byterover Cipher](https://github.com/campfirein/cipher) | Memory layer | Open-source memory for coding agents. Works with Claude Code, Cursor, Cline, and more. |
 | [mem0](https://github.com/mem0ai/mem0) | Memory layer | Self-improving memory for AI agents. Learns from interactions. |
 | [Letta (MemGPT)](https://github.com/letta-ai/letta) | Agent framework | Agents with persistent memory and self-editing capabilities. |
+| [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) | Memory layer | Framework-agnostic Rust CLI memory layer for coding agents with local recall, forgetting, audit, and TUI workflows. |
 | [Zep](https://github.com/getzep/zep) | Memory store | Long-term memory for AI assistants. Fast retrieval and summarization. |
 
 ---


### PR DESCRIPTION
## Summary

Adds Tree Ring Memory to the AI Agent Memory & Context table.

## Type of Change

- [x] New tool/resource
- [ ] Update existing entry
- [ ] Fix broken link
- [ ] Improve documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] Tool/resource follows the awesome list format
- [x] Links are working and tested
- [x] Entry includes the fields used by this section: Tool name, Type, Why It's Awesome
- [x] No promotional/marketing language (focus on utility)
- [x] Alphabetical order maintained (if applicable)

## Additional Context

Tree Ring Memory is a framework-agnostic Rust CLI memory layer for coding agents, with local recall, forgetting, audit, and TUI workflows.