### PR TITLE
Add DevIntern

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ AI that doesn't just assist — it works independently on complex tasks. [Creati
 | [Jules](https://jules.google/) | Free preview | Async bug fixes | Google's autonomous coding agent. Handles GitHub issues asynchronously with multi-step planning and execution. [Alternatives →](https://www.taskade.com/blog/devin-ai-alternatives) |
 | [OpenCode](https://github.com/sst/opencode) | Free | Coordination | Open-source coding agent for iterative implementation and review loops. |
 | [Parallel Code](https://github.com/johannesjo/parallel-code) | Free | Parallel local agents | Open-source desktop app for running Claude Code, Codex CLI, Gemini CLI, and other terminal agents in parallel, with per-task Git worktrees, terminal panes, diff review, and merge controls. |
+| [DevIntern](https://github.com/getdevintern/devintern) | Free tier | Ticket-to-PR workflows | Picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, and others), on your machines with your own model keys. A feasibility gate flags vague tickets back to the tracker with questions; the companion devpm tool creates codebase-grounded tickets from rough prompts. |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [DevIntern](https://github.com/getdevintern/devintern) to the AI Agents & Autonomous Coding table. DevIntern picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode, Gemini CLI, and others), running on your machines with your own model keys. A feasibility gate flags vague tickets back to the tracker with questions, and an optional unattended mode schedules ticket pickup and turns PR review comments into commits. The companion devpm tool creates well-specified, codebase-grounded tickets from rough prompts. Website: https://devintern.com/ · Docs: https://devintern.com/docs

## Type of Change

- [x] New tool/resource
- [ ] Update existing entry
- [ ] Fix broken link
- [ ] Improve documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](../CONTRIBUTING.md)
- [x] Tool/resource follows the awesome list format
- [x] Links are working and tested
- [x] Entry includes: Tool name, Pricing, Best For, Why It's Awesome
- [x] No promotional/marketing language (focus on utility)
- [x] Alphabetical order maintained (if applicable)

## Additional Context

License is FSL-1.1 (source-available), free for interactive use. Added to the bottom of the table, following the section's existing (non-alphabetical) ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)