### PR TITLE
Add a UI finish gate to code quality workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ Maintain quality when AI generates your code.
 | **Steering Files** | Use .cursorrules, AGENTS.md, or CLAUDE.md to set coding standards, conventions, and constraints. | [Documentation & Templates](#documentation--templates) |
 | **Lock Dependencies** | Specify exact versions in your steering files. AI may suggest outdated or incompatible package versions. | Practitioner consensus |
 | **Run Tests Before & After** | Always run your test suite before and after AI modifications. Catch regressions immediately. | Practitioner consensus |
+| **UI Finish Gate** | Before shipping an agent-built interface, compare it with real product references and reject it if its hierarchy, density, responsive behavior, states, or copy could belong to any product. | [UIZZE workflow](https://uizze.com) |
 
 ### Harness Engineering
 


### PR DESCRIPTION
## Summary

Adds one concrete UI finish-gate practice to **Code Quality & Review**. It tells vibe coders to compare agent-built interfaces with real product references and reject output whose hierarchy, density, responsive behavior, states, or copy remain generic.

This is a free, actionable workflow contribution rather than a hosted-MCP listing or naked product drop.

## Type of Change

- [x] New tool/resource
- [ ] Update existing entry
- [ ] Fix broken link
- [x] Improve documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](../CONTRIBUTING.md)
- [x] Tool/resource follows the awesome list format
- [x] Links are working and tested
- [x] Entry includes the practice, value, and source in the existing table format
- [x] No promotional/marketing language (focus on utility)
- [x] Existing section order is maintained

## Validation

- `npx --yes awesome-lint` — passes
- `git diff --check` — passes
- Full repository link check verifies the new UIZZE URL; it still reports four unrelated links already dead on `main`

## Additional Context

This replaces the broader hosted-MCP scope question in #45 with a smaller, workflow-first contribution. Disclosure: I help maintain UIZZE, the linked public reference workflow.
