### PR TITLE
Add Nhost to AI Database & Backend Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Generate and manage data layers with AI.
 | [Neon](https://neon.tech/) | Free tier | Serverless Postgres | Branching databases with AI queries. |
 | [Convex](https://www.convex.dev/) | Free tier | Real-time apps | Backend-as-a-service with AI code generation. |
 | [Firebase + Gemini](https://firebase.google.com/) | Free tier | Mobile backends | Google's AI integrated into Firebase. |
+| [Nhost](https://nhost.io/) | Free tier | GraphQL Postgres apps | Open-source backend: Postgres, instant Hasura GraphQL API, auth, storage, and serverless functions. 
 
 ---
 


### PR DESCRIPTION
Summary: Adds Nhost to the AI Database & Backend Tools table.

Nhost is an open-source backend for building app data layers: a Postgres database with an instant Hasura GraphQL API, plus authentication, storage, and serverless functions. It fits alongside the existing Supabase, Neon and Convex entries as a backend you can stand up while vibe-coding.

Type of change: new tool/resource.

The row follows the table format (Tool | Pricing | Best For | Why It's Awesome), the links work, the description is utility-focused with no promotional language, and it is not a duplicate.

Links: https://nhost.io/ and https://github.com/nhost/nhost