### PR TITLE
docs: add SandBase CLI to terminal tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Full-featured coding agents that work from the command line.
 | [RA.Aid](https://github.com/ai-christianson/RA.Aid) | Free | Research tasks | Research-focused AI dev agent. Combines coding with information gathering. |
 | [aichat](https://github.com/sigoden/aichat) | Free | Multi-provider CLI | All-in-one LLM CLI supporting 20+ providers. Shell integration, RAG, and function calling. |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | Free | Config generation | Fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality, auto-refreshes. |
+| [SandBase CLI](https://github.com/sandbaseai/cli) | Free | Multi-provider model access | Open-source CLI and local MCP bridge that connects AI clients to 2,000+ model APIs through one interface. |
 
 ### AI-Enhanced Terminals
 


### PR DESCRIPTION
## Summary
- add SandBase CLI to the AI Coding CLIs table
- describe its open-source CLI and local MCP bridge for 2,000+ model APIs

Project: https://github.com/sandbaseai/cli