### PR TITLE
Add d1v to Specialized CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Tools for specific coding workflows.
 | [ax](https://github.com/Necmttn/ax) | Free | Session observability | Local telemetry and recall graph for Claude Code, Codex, Cursor, OpenCode, and Pi sessions, tools, skills, and cost. |
 | [GPT Pilot](https://github.com/Pythagora-io/gpt-pilot) | Free | Full app dev | Builds entire apps from scratch. Interactive development with AI. |
 | [Sweep](https://sweep.dev/) | Free tier | GitHub PRs | AI junior developer. Handles issues and creates PRs automatically. |
+| [d1v](https://github.com/d1vai/d1v-cli) | Free | AI-built web deployments | CLI workflow that waits for verified previews and requires explicit confirmation before production releases. |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [d1v](https://github.com/d1vai/d1v-cli) to **CLI & Terminal Tools -> Specialized CLI Tools** as a free CLI workflow for verified preview and explicitly confirmed production deployments.

## Type of Change

- [x] New tool/resource
- [ ] Update existing entry
- [ ] Fix broken link
- [ ] Improve documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](../CONTRIBUTING.md)
- [x] Tool/resource follows the awesome list format
- [x] Links are working and tested
- [x] Entry includes: Tool name, Pricing, Best For, Why It's Awesome
- [x] No promotional/marketing language (focus on utility)
- [x] Alphabetical order is not applicable: this table is not alphabetized, and the contribution guide requires new rows at its bottom.

## Additional Context

The source repository has an MIT license, setup documentation, and recent activity. The entry describes only documented behavior: preview deployments wait for a verified terminal state, while production releases require an interactive terminal and explicit confirmation.

Project disclosure: I am submitting this entry for d1v.
