### PR TITLE
Add OrcaReplay to Benchmarks & Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,7 +686,7 @@ Measure AI coding capabilities.
 | [SWE-agent](https://github.com/SWE-agent/SWE-agent) | Agent | Princeton's AI agent that resolves GitHub issues. Top SWE-bench performer. |
 | [Aider Leaderboard](https://aider.chat/docs/leaderboards/) | Benchmark | Compares AI models on real coding tasks. Updated regularly. |
 | [Vibe Coding Profiler](https://www.vibe-coding-profiler.com/) | Profiler | Analyzes git history to reveal your AI-assisted engineering style and vibe coding persona. |
-| [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | Record/Replay | Records an agent run below the harness and replays it offline byte-for-byte, so a failure is reproducible instead of intermittent. Forks from any checkpoint onto another model to compare decisions from identical state. |
+| [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | Record/Replay | Records an agent run below the harness and replays it offline with the network off, so a failure is reproducible instead of intermittent. Forks from any checkpoint onto another model to compare decisions from identical state. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -686,6 +686,7 @@ Measure AI coding capabilities.
 | [SWE-agent](https://github.com/SWE-agent/SWE-agent) | Agent | Princeton's AI agent that resolves GitHub issues. Top SWE-bench performer. |
 | [Aider Leaderboard](https://aider.chat/docs/leaderboards/) | Benchmark | Compares AI models on real coding tasks. Updated regularly. |
 | [Vibe Coding Profiler](https://www.vibe-coding-profiler.com/) | Profiler | Analyzes git history to reveal your AI-assisted engineering style and vibe coding persona. |
+| [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | Record/Replay | Records an agent run below the harness and replays it offline byte-for-byte, so a failure is reproducible instead of intermittent. Forks from any checkpoint onto another model to compare decisions from identical state. |
 
 ---
 


### PR DESCRIPTION
Adds OrcaReplay to **Benchmarks & Evaluation**.

The entries there measure AI coding capability across tasks. OrcaReplay measures it on **your** task: fork a recorded run from any checkpoint onto a different model, with every earlier turn still served from the recording, so both models face byte-identical context and file state. That is a head-to-head on the work you actually do, rather than on SWE-bench.

The recording side is what makes it possible. Capture sits at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP calls all land on one timeline; replaying with the network off reproduces the run byte-for-byte, which turns an intermittent agent failure into something you can rerun.

Row matches the table's three columns (Tool / Type / Why It's Awesome). Apache-2.0, `npm i -g orcareplay`, Node 20+. Works with Claude Code, Codex, opencode, Qwen Code, Cursor and others.
